### PR TITLE
Fix featured destination image sizing

### DIFF
--- a/main.css
+++ b/main.css
@@ -216,6 +216,7 @@ nav ul {
   overflow: hidden;
 }
 .card img {
+  width: 100%;
   height: 100%;
   object-fit: cover;
 }


### PR DESCRIPTION
## Summary
- force destination card images to stretch across the card container
- keep images covering their cards without distortion by combining width and height with object-fit

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0dd353ba083258b17002970668aaf