### PR TITLE
Fix contact image layout next to form

### DIFF
--- a/main.css
+++ b/main.css
@@ -308,6 +308,15 @@ nav ul {
   border-radius: 18px;
   padding: 22px;
 }
+.contacto .panel:last-child {
+  display: flex;
+}
+.contacto .panel:last-child img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  flex: 1;
+}
 form {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## Summary
- force the contact image panel to use flex layout so its photo stretches with the form height
- ensure the photo fills the entire panel using full width, height, and object-fit cover

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0e5efb5448325849e680fe9ceab53