### PR TITLE
Add admin interface to manage landing images

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Rustica Travel — Administrador de imágenes</title>
+    <meta
+      name="description"
+      content="Gestiona la biblioteca de imágenes que se muestran en el landing page de Rustica Travel."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="main.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container nav">
+        <a href="index.html" class="brand" aria-label="Rustica Travel">
+          <span class="dot"></span>
+          <span>Rustica <span style="color: var(--sand)">Travel</span></span>
+        </a>
+        <nav id="nav">
+          <button
+            class="menu-btn"
+            aria-label="Abrir menú"
+            onclick="document.getElementById('nav').classList.toggle('open')"
+          >
+            ☰
+          </button>
+          <ul>
+            <li><a href="index.html">Ver landing</a></li>
+            <li>
+              <a href="admin.html" class="active" aria-current="page"
+                >Administrador de imágenes</a
+              >
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="admin-main">
+      <div class="container">
+        <h1 class="title">Administrador de imágenes</h1>
+        <p class="subtitle">
+          Controla la biblioteca visual que alimenta el landing page de Rustica Travel.
+        </p>
+        <p class="admin-note">
+          Las imágenes y sus asignaciones se guardan de manera local en tu navegador mediante
+          <strong>localStorage</strong>. Si accedes desde otro dispositivo necesitarás configurarlas
+          nuevamente.
+        </p>
+
+        <div class="admin-layout">
+          <section class="admin-card shadow-soft">
+            <h2>Agregar nueva imagen</h2>
+            <p class="admin-note">
+              Sube un archivo (se convertirá en un recurso base64) o pega un enlace público. El texto
+              alternativo se utilizará para describir la imagen en el sitio.
+            </p>
+            <form id="imageForm">
+              <div class="form-group">
+                <label for="imageName">Nombre de referencia</label>
+                <input
+                  type="text"
+                  id="imageName"
+                  name="imageName"
+                  placeholder="Ej. Playa secreta"
+                  required
+                />
+              </div>
+              <div class="form-group">
+                <label for="imageAlt">Texto alternativo</label>
+                <input
+                  type="text"
+                  id="imageAlt"
+                  name="imageAlt"
+                  placeholder="Describe el contenido de la imagen"
+                  required
+                />
+              </div>
+              <div class="form-group inline">
+                <div class="form-group">
+                  <label for="imageFile">Subir archivo</label>
+                  <input type="file" id="imageFile" name="imageFile" accept="image/*" />
+                </div>
+                <div class="form-group">
+                  <label for="imageUrl">O pegar URL pública</label>
+                  <input type="url" id="imageUrl" name="imageUrl" placeholder="https://..." />
+                </div>
+              </div>
+              <p class="admin-note">Si completas ambas opciones se priorizará el archivo cargado.</p>
+              <button class="btn btn-primary" type="submit">Guardar en la biblioteca</button>
+              <p class="form-message" id="formMessage" aria-live="polite"></p>
+            </form>
+          </section>
+
+          <section class="admin-card shadow-soft">
+            <h2>Biblioteca disponible</h2>
+            <p class="admin-note">
+              Visualiza todas las imágenes personalizadas y elimina las que ya no utilices.
+            </p>
+            <div id="libraryList" class="library-grid" aria-live="polite"></div>
+          </section>
+        </div>
+
+        <section class="admin-card shadow-soft" style="margin-top: 32px">
+          <h2>Asignar imágenes al sitio</h2>
+          <p class="admin-note">
+            Selecciona qué imagen debe mostrarse en cada sección del landing. Al dejar la opción
+            predeterminada se conservará la fotografía original del diseño.
+          </p>
+          <div id="slotAssignments" class="slot-grid" aria-live="polite"></div>
+        </section>
+      </div>
+    </main>
+
+    <script src="admin.js"></script>
+  </body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,452 @@
+const LIBRARY_STORAGE_KEY = "rusticaImageLibrary";
+const ASSIGNMENTS_STORAGE_KEY = "rusticaImageAssignments";
+
+const IMAGE_SLOTS = [
+  {
+    key: "hero-1",
+    label: "Hero principal — Imagen 1",
+    description: "Primera fotografía del slider de portada.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1505761671935-60b3a7427bad?q=80&w=2000&auto=format&fit=crop",
+    defaultAlt: "Playa turquesa",
+  },
+  {
+    key: "hero-2",
+    label: "Hero principal — Imagen 2",
+    description: "Segunda fotografía del slider de portada.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1469474968028-56623f02e42e?q=80&w=2000&auto=format&fit=crop",
+    defaultAlt: "Ciudad europea al atardecer",
+  },
+  {
+    key: "hero-3",
+    label: "Hero principal — Imagen 3",
+    description: "Tercera fotografía del slider de portada.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1483683804023-6ccdb62f86ef?q=80&w=2000&auto=format&fit=crop",
+    defaultAlt: "Montañas y lago",
+  },
+  {
+    key: "destinos-1",
+    label: "Destinos destacados — Caribe",
+    description: "Imagen principal del mosaico de destinos (Caribe).",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1500375592092-40eb2168fd21?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Caribe, arena blanca y mar turquesa",
+  },
+  {
+    key: "destinos-2",
+    label: "Destinos destacados — Roma & Mediterráneo",
+    description: "Tarjeta de destinos dedicada a Roma y el Mediterráneo.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1473959383410-a6f58845af88?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Roma, Italia",
+  },
+  {
+    key: "destinos-3",
+    label: "Destinos destacados — Iguazú",
+    description: "Tarjeta del mosaico con las Cataratas del Iguazú.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1431274172761-fca41d930114?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Cataratas del Iguazú",
+  },
+  {
+    key: "destinos-4",
+    label: "Destinos destacados — Estambul",
+    description: "Tarjeta del mosaico dedicada a Estambul.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1488459716781-31db52582fe9?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Estambul, Turquía",
+  },
+  {
+    key: "destinos-5",
+    label: "Destinos destacados — Riviera Maya",
+    description: "Tarjeta del mosaico dedicada a la Riviera Maya.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Riviera Maya",
+  },
+  {
+    key: "destinos-6",
+    label: "Destinos destacados — Panamá",
+    description: "Tarjeta del mosaico dedicada a Panamá.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1511735111819-9a3f7709049c?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Panamá ciudad y playa",
+  },
+  {
+    key: "promo-1",
+    label: "Promociones — Cartagena 4D/3N",
+    description: "Primera tarjeta de promociones activas.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1493558103817-58b2924bce98?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Cartagena de Indias",
+  },
+  {
+    key: "promo-2",
+    label: "Promociones — Buenos Aires 4D/3N",
+    description: "Segunda tarjeta de promociones activas.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1530789253388-582c481c54b0?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Buenos Aires",
+  },
+  {
+    key: "promo-3",
+    label: "Promociones — Punta Cana 5D/4N",
+    description: "Tercera tarjeta de promociones activas.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1505764706515-aa95265c5abc?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Punta Cana",
+  },
+  {
+    key: "testimonio-1",
+    label: "Testimonios — Pareja en la playa",
+    description: "Primera historia destacada en testimonios.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1544006659-f0b21884ce1d?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Pareja en la playa",
+  },
+  {
+    key: "testimonio-2",
+    label: "Testimonios — Familia viajando",
+    description: "Segunda historia destacada en testimonios.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1515886657613-9f3515b0c78f?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Familia viajando",
+  },
+  {
+    key: "testimonio-3",
+    label: "Testimonios — Grupo de amigos",
+    description: "Tercera historia destacada en testimonios.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1531259683007-016a7b628fc3?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Grupo de amigos en ciudad europea",
+  },
+  {
+    key: "contacto-panel",
+    label: "Contacto — Imagen lateral",
+    description: "Fotografía que acompaña al formulario de contacto.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1469474968028-56623f02e42e?q=80&w=1600&auto=format&fit=crop",
+    defaultAlt: "Atardecer sobre una ciudad costera",
+  },
+  {
+    key: "footer-bg",
+    label: "Footer — Fondo marino",
+    description: "Imagen de fondo oscurecida en el pie de página.",
+    defaultSrc:
+      "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?q=80&w=2000&auto=format&fit=crop",
+    defaultAlt: "Fondo marino",
+  },
+];
+
+const form = document.getElementById("imageForm");
+const libraryList = document.getElementById("libraryList");
+const slotAssignments = document.getElementById("slotAssignments");
+const messageElement = document.getElementById("formMessage");
+const fileInput = document.getElementById("imageFile");
+const urlInput = document.getElementById("imageUrl");
+
+function loadLibrary() {
+  try {
+    const stored = localStorage.getItem(LIBRARY_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error("No se pudieron cargar las imágenes guardadas.", error);
+    return [];
+  }
+}
+
+function saveLibrary(library) {
+  try {
+    localStorage.setItem(LIBRARY_STORAGE_KEY, JSON.stringify(library));
+    return true;
+  } catch (error) {
+    console.error("No se pudo guardar la biblioteca de imágenes.", error);
+    setMessage(
+      "No se pudo guardar la biblioteca en este navegador. Verifica el espacio disponible.",
+      "error"
+    );
+    return false;
+  }
+}
+
+function loadAssignments() {
+  try {
+    const stored = localStorage.getItem(ASSIGNMENTS_STORAGE_KEY);
+    if (!stored) {
+      return {};
+    }
+    const parsed = JSON.parse(stored);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (error) {
+    console.error("No se pudieron cargar las asignaciones guardadas.", error);
+    return {};
+  }
+}
+
+function saveAssignments(assignments) {
+  try {
+    localStorage.setItem(ASSIGNMENTS_STORAGE_KEY, JSON.stringify(assignments));
+    return true;
+  } catch (error) {
+    console.error("No se pudieron guardar las asignaciones.", error);
+    return false;
+  }
+}
+
+function setMessage(text, type) {
+  if (!messageElement) {
+    return;
+  }
+  messageElement.textContent = text;
+  messageElement.classList.remove("success", "error");
+  if (type) {
+    messageElement.classList.add(type);
+  }
+}
+
+function readFileAsDataURL(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(new Error("No se pudo leer el archivo"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function renderLibrary() {
+  if (!libraryList) {
+    return;
+  }
+
+  const library = loadLibrary();
+  libraryList.innerHTML = "";
+
+  if (library.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "admin-note";
+    empty.textContent = "Aún no has agregado imágenes personalizadas.";
+    libraryList.append(empty);
+    return;
+  }
+
+  library.forEach((image) => {
+    const card = document.createElement("article");
+    card.className = "library-card";
+
+    const preview = document.createElement("img");
+    preview.src = image.src;
+    preview.alt = image.alt || image.name || "Imagen subida";
+    card.append(preview);
+
+    const body = document.createElement("div");
+    body.className = "library-body";
+
+    const title = document.createElement("h3");
+    title.textContent = image.name;
+    body.append(title);
+
+    const alt = document.createElement("p");
+    alt.className = "small";
+    alt.textContent = image.alt || "Sin texto alternativo";
+    body.append(alt);
+
+    card.append(body);
+
+    const actions = document.createElement("div");
+    actions.className = "library-actions";
+
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.className = "delete-btn";
+    deleteButton.textContent = "Eliminar";
+    deleteButton.addEventListener("click", () => {
+      const confirmDelete = window.confirm(
+        `¿Eliminar "${image.name}" de la biblioteca? Esta acción también quitará su uso del sitio.`
+      );
+      if (!confirmDelete) {
+        return;
+      }
+      deleteImage(image.id);
+    });
+
+    actions.append(deleteButton);
+    card.append(actions);
+    libraryList.append(card);
+  });
+}
+
+function renderSlots() {
+  if (!slotAssignments) {
+    return;
+  }
+
+  const assignments = loadAssignments();
+  const library = loadLibrary();
+  const libraryMap = new Map(library.map((image) => [image.id, image]));
+
+  slotAssignments.innerHTML = "";
+
+  IMAGE_SLOTS.forEach((slot) => {
+    const card = document.createElement("article");
+    card.className = "slot-card shadow-soft";
+
+    const currentImage = libraryMap.get(assignments[slot.key]);
+
+    const preview = document.createElement("img");
+    preview.src = currentImage?.src || slot.defaultSrc;
+    preview.alt = currentImage?.alt || slot.defaultAlt;
+    card.append(preview);
+
+    const title = document.createElement("h3");
+    title.textContent = slot.label;
+    card.append(title);
+
+    if (slot.description) {
+      const description = document.createElement("p");
+      description.className = "slot-description";
+      description.textContent = slot.description;
+      card.append(description);
+    }
+
+    const status = document.createElement("p");
+    status.className = "slot-status";
+    status.textContent = currentImage
+      ? `Usando: ${currentImage.name}`
+      : "Usando imagen predeterminada.";
+    card.append(status);
+
+    const select = document.createElement("select");
+    const defaultOption = document.createElement("option");
+    defaultOption.value = "";
+    defaultOption.textContent = "Usar imagen predeterminada";
+    select.append(defaultOption);
+
+    library.forEach((image) => {
+      const option = document.createElement("option");
+      option.value = image.id;
+      option.textContent = image.name;
+      select.append(option);
+    });
+
+    select.value = currentImage ? currentImage.id : "";
+    select.addEventListener("change", () => {
+      const updatedAssignments = loadAssignments();
+      if (select.value) {
+        updatedAssignments[slot.key] = select.value;
+      } else {
+        delete updatedAssignments[slot.key];
+      }
+      saveAssignments(updatedAssignments);
+      renderSlots();
+    });
+
+    card.append(select);
+    slotAssignments.append(card);
+  });
+}
+
+function deleteImage(imageId) {
+  const library = loadLibrary();
+  const filtered = library.filter((image) => image.id !== imageId);
+  if (filtered.length === library.length) {
+    return;
+  }
+
+  if (!saveLibrary(filtered)) {
+    return;
+  }
+
+  const assignments = loadAssignments();
+  let updated = false;
+  Object.keys(assignments).forEach((key) => {
+    if (assignments[key] === imageId) {
+      delete assignments[key];
+      updated = true;
+    }
+  });
+
+  if (updated) {
+    saveAssignments(assignments);
+  }
+
+  renderLibrary();
+  renderSlots();
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  setMessage("", "");
+
+  const formData = new FormData(form);
+  const name = String(formData.get("imageName") || "").trim();
+  const alt = String(formData.get("imageAlt") || "").trim();
+  const url = String(formData.get("imageUrl") || "").trim();
+  const file = fileInput?.files?.[0];
+
+  if (!name || !alt) {
+    setMessage("Completa el nombre y el texto alternativo de la imagen.", "error");
+    return;
+  }
+
+  if (!file && !url) {
+    setMessage("Sube un archivo o proporciona una URL pública para la imagen.", "error");
+    return;
+  }
+
+  let src = "";
+  if (file) {
+    try {
+      src = await readFileAsDataURL(file);
+    } catch (error) {
+      console.error(error);
+      setMessage("No se pudo leer el archivo seleccionado.", "error");
+      return;
+    }
+  } else {
+    src = url;
+  }
+
+  const library = loadLibrary();
+  const newImage = {
+    id: `img-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    name,
+    alt,
+    src,
+  };
+  library.push(newImage);
+
+  if (!saveLibrary(library)) {
+    return;
+  }
+
+  form.reset();
+  setMessage("Imagen guardada en la biblioteca.", "success");
+  renderLibrary();
+  renderSlots();
+}
+
+if (form) {
+  form.addEventListener("submit", handleSubmit);
+}
+
+if (fileInput && urlInput) {
+  fileInput.addEventListener("change", () => {
+    if (fileInput.files && fileInput.files.length > 0) {
+      urlInput.value = "";
+    }
+  });
+  urlInput.addEventListener("input", () => {
+    if (urlInput.value) {
+      fileInput.value = "";
+    }
+  });
+}
+
+renderLibrary();
+renderSlots();

--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
             <li><a href="#destinos">Destinos</a></li>
             <li><a href="#promos">Promociones</a></li>
             <li><a href="#contacto">Contacto</a></li>
+            <li>
+              <a href="admin.html">Administrador de imágenes</a>
+            </li>
           </ul>
         </nav>
       </div>
@@ -46,18 +49,27 @@
       <div class="slides" id="slides">
         <div class="slide">
           <img
+            data-image-key="hero-1"
+            data-default-src="https://images.unsplash.com/photo-1505761671935-60b3a7427bad?q=80&w=2000&auto=format&fit=crop"
+            data-default-alt="Playa turquesa"
             src="https://images.unsplash.com/photo-1505761671935-60b3a7427bad?q=80&w=2000&auto=format&fit=crop"
             alt="Playa turquesa"
           />
         </div>
         <div class="slide">
           <img
+            data-image-key="hero-2"
+            data-default-src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?q=80&w=2000&auto=format&fit=crop"
+            data-default-alt="Ciudad europea al atardecer"
             src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?q=80&w=2000&auto=format&fit=crop"
             alt="Ciudad europea al atardecer"
           />
         </div>
         <div class="slide">
           <img
+            data-image-key="hero-3"
+            data-default-src="https://images.unsplash.com/photo-1483683804023-6ccdb62f86ef?q=80&w=2000&auto=format&fit=crop"
+            data-default-alt="Montañas y lago"
             src="https://images.unsplash.com/photo-1483683804023-6ccdb62f86ef?q=80&w=2000&auto=format&fit=crop"
             alt="Montañas y lago"
           />
@@ -105,6 +117,9 @@
             style="grid-column: span 6; height: 320px"
           >
             <img
+              data-image-key="destinos-1"
+              data-default-src="https://images.unsplash.com/photo-1500375592092-40eb2168fd21?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Caribe, arena blanca y mar turquesa"
               src="https://images.unsplash.com/photo-1500375592092-40eb2168fd21?q=80&w=1600&auto=format&fit=crop"
               alt="Caribe, arena blanca y mar turquesa"
             />
@@ -118,6 +133,9 @@
             style="grid-column: span 3; height: 320px"
           >
             <img
+              data-image-key="destinos-2"
+              data-default-src="https://images.unsplash.com/photo-1473959383410-a6f58845af88?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Roma, Italia"
               src="https://images.unsplash.com/photo-1473959383410-a6f58845af88?q=80&w=1600&auto=format&fit=crop"
               alt="Roma, Italia"
             />
@@ -128,6 +146,9 @@
             style="grid-column: span 3; height: 320px"
           >
             <img
+              data-image-key="destinos-3"
+              data-default-src="https://images.unsplash.com/photo-1431274172761-fca41d930114?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Cataratas del Iguazú"
               src="https://images.unsplash.com/photo-1431274172761-fca41d930114?q=80&w=1600&auto=format&fit=crop"
               alt="Cataratas del Iguazú"
             />
@@ -138,6 +159,9 @@
             style="grid-column: span 4; height: 280px"
           >
             <img
+              data-image-key="destinos-4"
+              data-default-src="https://images.unsplash.com/photo-1488459716781-31db52582fe9?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Estambul, Turquía"
               src="https://images.unsplash.com/photo-1488459716781-31db52582fe9?q=80&w=1600&auto=format&fit=crop"
               alt="Estambul, Turquía"
             />
@@ -151,6 +175,9 @@
             style="grid-column: span 4; height: 280px"
           >
             <img
+              data-image-key="destinos-5"
+              data-default-src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Riviera Maya"
               src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?q=80&w=1600&auto=format&fit=crop"
               alt="Riviera Maya"
             />
@@ -161,6 +188,9 @@
             style="grid-column: span 4; height: 280px"
           >
             <img
+              data-image-key="destinos-6"
+              data-default-src="https://images.unsplash.com/photo-1511735111819-9a3f7709049c?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Panamá ciudad y playa"
               src="https://images.unsplash.com/photo-1511735111819-9a3f7709049c?q=80&w=1600&auto=format&fit=crop"
               alt="Panamá ciudad y playa"
             />
@@ -196,6 +226,9 @@
         <div class="promos">
           <article class="promo shadow-soft">
             <img
+              data-image-key="promo-1"
+              data-default-src="https://images.unsplash.com/photo-1493558103817-58b2924bce98?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Cartagena de Indias"
               src="https://images.unsplash.com/photo-1493558103817-58b2924bce98?q=80&w=1600&auto=format&fit=crop"
               alt="Cartagena de Indias"
             />
@@ -207,6 +240,9 @@
           </article>
           <article class="promo shadow-soft">
             <img
+              data-image-key="promo-2"
+              data-default-src="https://images.unsplash.com/photo-1530789253388-582c481c54b0?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Buenos Aires"
               src="https://images.unsplash.com/photo-1530789253388-582c481c54b0?q=80&w=1600&auto=format&fit=crop"
               alt="Buenos Aires"
             />
@@ -218,6 +254,9 @@
           </article>
           <article class="promo shadow-soft">
             <img
+              data-image-key="promo-3"
+              data-default-src="https://images.unsplash.com/photo-1505764706515-aa95265c5abc?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Punta Cana"
               src="https://images.unsplash.com/photo-1505764706515-aa95265c5abc?q=80&w=1600&auto=format&fit=crop"
               alt="Punta Cana"
             />
@@ -239,6 +278,9 @@
         <div class="testis">
           <figure class="testi shadow-soft">
             <img
+              data-image-key="testimonio-1"
+              data-default-src="https://images.unsplash.com/photo-1544006659-f0b21884ce1d?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Pareja en la playa"
               src="https://images.unsplash.com/photo-1544006659-f0b21884ce1d?q=80&w=1600&auto=format&fit=crop"
               alt="Pareja en la playa"
             />
@@ -248,6 +290,9 @@
           </figure>
           <figure class="testi shadow-soft">
             <img
+              data-image-key="testimonio-2"
+              data-default-src="https://images.unsplash.com/photo-1515886657613-9f3515b0c78f?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Familia viajando"
               src="https://images.unsplash.com/photo-1515886657613-9f3515b0c78f?q=80&w=1600&auto=format&fit=crop"
               alt="Familia viajando"
             />
@@ -257,6 +302,9 @@
           </figure>
           <figure class="testi shadow-soft">
             <img
+              data-image-key="testimonio-3"
+              data-default-src="https://images.unsplash.com/photo-1531259683007-016a7b628fc3?q=80&w=1600&auto=format&fit=crop"
+              data-default-alt="Grupo de amigos en ciudad europea"
               src="https://images.unsplash.com/photo-1531259683007-016a7b628fc3?q=80&w=1600&auto=format&fit=crop"
               alt="Grupo de amigos en ciudad europea"
             />
@@ -311,6 +359,9 @@
         </div>
         <div class="panel" style="padding: 0; overflow: hidden">
           <img
+            data-image-key="contacto-panel"
+            data-default-src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?q=80&w=1600&auto=format&fit=crop"
+            data-default-alt="Atardecer sobre una ciudad costera"
             src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?q=80&w=1600&auto=format&fit=crop"
             alt="Atardecer sobre una ciudad costera"
           />
@@ -322,6 +373,9 @@
     <footer>
       <img
         class="bg"
+        data-image-key="footer-bg"
+        data-default-src="https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?q=80&w=2000&auto=format&fit=crop"
+        data-default-alt="Fondo marino"
         src="https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?q=80&w=2000&auto=format&fit=crop"
         alt="Fondo marino"
       />

--- a/main.css
+++ b/main.css
@@ -117,6 +117,10 @@ nav ul {
   margin: 0;
   padding: 0;
 }
+nav a.active {
+  color: var(--blue);
+  font-weight: 700;
+}
 .menu-btn {
   display: none;
   border: 0;
@@ -334,6 +338,133 @@ textarea {
   min-height: 120px;
 }
 
+/* Administrador de imágenes */
+.admin-main {
+  padding: 120px 0 80px;
+}
+.admin-main .title {
+  margin-bottom: 8px;
+}
+.admin-note {
+  font-size: 0.9rem;
+  color: #475569;
+}
+.admin-layout {
+  display: grid;
+  gap: 24px;
+  margin-top: 32px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.admin-card {
+  background: #fff;
+  border-radius: 18px;
+  padding: 24px;
+  display: grid;
+  gap: 18px;
+}
+.form-group {
+  display: grid;
+  gap: 10px;
+}
+.form-group.inline {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+.form-message {
+  font-size: 0.85rem;
+  color: #475569;
+}
+.form-message.success {
+  color: #15803d;
+}
+.form-message.error {
+  color: #b91c1c;
+}
+.library-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.library-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #fff;
+  display: grid;
+}
+.library-card img {
+  width: 100%;
+  aspect-ratio: 16/10;
+  object-fit: cover;
+}
+.library-card .library-body {
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+}
+.library-card h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+.library-card .small {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #475569;
+}
+.library-card .library-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 16px 16px;
+}
+.delete-btn {
+  border: 0;
+  background: rgba(237, 7, 71, 0.12);
+  color: var(--fuchsia);
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.delete-btn:hover {
+  background: rgba(237, 7, 71, 0.18);
+}
+.slot-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+.slot-card {
+  background: #fff;
+  border-radius: 18px;
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+}
+.slot-card img {
+  width: 100%;
+  border-radius: 14px;
+  aspect-ratio: 16/9;
+  object-fit: cover;
+}
+.slot-card h3 {
+  margin: 0;
+}
+.slot-description {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin: 0;
+}
+.slot-status {
+  font-size: 0.85rem;
+  color: #475569;
+}
+.slot-card select {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid #d4d4d8;
+  font-family: inherit;
+}
+
 /* Footer con imagen */
 footer {
   position: relative;
@@ -358,6 +489,9 @@ footer .inner {
 /* Responsivo */
 @media (max-width: 960px) {
   .contacto {
+    grid-template-columns: 1fr;
+  }
+  .admin-layout {
     grid-template-columns: 1fr;
   }
   nav ul {

--- a/main.js
+++ b/main.js
@@ -1,11 +1,75 @@
 // Rustica Travel - JS extraído de index.html
-// Año dinámico
-document.getElementById("y").textContent = new Date().getFullYear();
+
+// Año dinámico (se valida la existencia por si el script se reutiliza en otra página)
+const yearElement = document.getElementById("y");
+if (yearElement) {
+  yearElement.textContent = new Date().getFullYear();
+}
+
+// Gestión de imágenes personalizables
+const LIBRARY_STORAGE_KEY = "rusticaImageLibrary";
+const ASSIGNMENTS_STORAGE_KEY = "rusticaImageAssignments";
+
+function loadLibraryFromStorage() {
+  try {
+    const stored = localStorage.getItem(LIBRARY_STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn("No se pudieron cargar las imágenes personalizadas.", error);
+    return [];
+  }
+}
+
+function loadAssignmentsFromStorage() {
+  try {
+    const stored = localStorage.getItem(ASSIGNMENTS_STORAGE_KEY);
+    if (!stored) {
+      return {};
+    }
+    const parsed = JSON.parse(stored);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (error) {
+    console.warn("No se pudieron cargar las asignaciones de imágenes.", error);
+    return {};
+  }
+}
+
+function applyManagedImages() {
+  const library = loadLibraryFromStorage();
+  const assignments = loadAssignmentsFromStorage();
+  const libraryMap = new Map(library.map((image) => [image.id, image]));
+
+  document.querySelectorAll("[data-image-key]").forEach((img) => {
+    const key = img.dataset.imageKey;
+    if (!key) {
+      return;
+    }
+    const defaultSrc = img.dataset.defaultSrc || img.getAttribute("src");
+    const defaultAlt = img.dataset.defaultAlt || img.getAttribute("alt") || "";
+    const imageId = assignments[key];
+    const customImage = imageId ? libraryMap.get(imageId) : undefined;
+
+    if (customImage && customImage.src) {
+      img.src = customImage.src;
+      img.alt = customImage.alt || defaultAlt;
+    } else {
+      img.src = defaultSrc;
+      img.alt = defaultAlt;
+    }
+  });
+}
+
+applyManagedImages();
 
 // Slider simple y ligero
 const slides = document.querySelectorAll(".slide");
 const dots = document.querySelectorAll(".indicator .dot");
 let idx = 0;
+
 function show(i) {
   slides.forEach((s, j) => {
     s.style.opacity = j === i ? 1 : 0;
@@ -16,8 +80,11 @@ function show(i) {
     d.classList.toggle("active", j === i);
   });
 }
-show(0);
-setInterval(() => {
-  idx = (idx + 1) % slides.length;
-  show(idx);
-}, 4500);
+
+if (slides.length > 0) {
+  show(0);
+  setInterval(() => {
+    idx = (idx + 1) % slides.length;
+    show(idx);
+  }, 4500);
+}


### PR DESCRIPTION
## Summary
- add a navigation entry and data attributes so landing images can be replaced from storage
- create an admin page to upload or link images, manage the library and assign assets to each landing slot
- enhance shared styles and scripts to apply stored selections across the landing hero, grids, promos, testimonios y footer

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0e8780ab4832580f59d476f578d10