### PR TITLE
Refactor admin panel layout to centralize section settings

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -65,39 +65,49 @@
             </p>
             <ol class="flow-list">
               <li>
-                <span class="flow-step">1</span>
-                <div>
-                  <h3>Hero de portada</h3>
-                  <p>Slider con grandes imágenes y los llamados a la acción principales.</p>
-                </div>
+                <button class="flow-link" type="button" data-target="section-hero">
+                  <span class="flow-step">1</span>
+                  <div>
+                    <h3>Hero de portada</h3>
+                    <p>Slider con grandes imágenes y los llamados a la acción principales.</p>
+                  </div>
+                </button>
               </li>
               <li>
-                <span class="flow-step">2</span>
-                <div>
-                  <h3>Destinos destacados</h3>
-                  <p>Mosaico con seis experiencias inspiradoras para descubrir.</p>
-                </div>
+                <button class="flow-link" type="button" data-target="section-destinos">
+                  <span class="flow-step">2</span>
+                  <div>
+                    <h3>Destinos destacados</h3>
+                    <p>Mosaico con seis experiencias inspiradoras para descubrir.</p>
+                  </div>
+                </button>
               </li>
               <li>
-                <span class="flow-step">3</span>
-                <div>
-                  <h3>Promociones activas</h3>
-                  <p>Tarjetas de ofertas con botón directo a la sección de contacto.</p>
-                </div>
+                <button class="flow-link" type="button" data-target="section-promos">
+                  <span class="flow-step">3</span>
+                  <div>
+                    <h3>Promociones activas</h3>
+                    <p>Tarjetas de ofertas con botón directo a la sección de contacto.</p>
+                  </div>
+                </button>
               </li>
               <li>
-                <span class="flow-step">4</span>
-                <div>
-                  <h3>Historias que inspiran</h3>
-                  <p>Testimonios reales respaldados por fotografías de clientes.</p>
-                </div>
+                <button class="flow-link" type="button" data-target="section-testimonios">
+                  <span class="flow-step">4</span>
+                  <div>
+                    <h3>Historias que inspiran</h3>
+                    <p>Testimonios reales respaldados por fotografías de clientes.</p>
+                  </div>
+                </button>
               </li>
               <li>
-                <span class="flow-step">5</span>
-                <div>
-                  <h3>Contacto y cierre</h3>
-                  <p>Formulario de cotización y una imagen final que refuerza la marca.</p>
-                </div>
+                <button class="flow-link" type="button" data-target="section-contacto">
+                  <span class="flow-step">5</span>
+                  <div>
+                    <h3>Contacto y cierre</h3>
+                    <p>Formulario de cotización y una imagen final que refuerza la marca.</p>
+                  </div>
+                </button>
               </li>
             </ol>
             <div class="overview-footnote">
@@ -160,35 +170,24 @@
               </section>
             </div>
 
-            <section class="admin-card shadow-soft">
-              <div class="section-heading">
-                <div>
-                  <h2>Asignar imágenes al sitio</h2>
-                  <p class="admin-note">
-                    Selecciona qué imagen debe mostrarse en cada sección del landing. Al dejar la opción
-                    predeterminada se conservará la fotografía original del diseño.
-                  </p>
-                </div>
-                <a class="btn btn-secondary" href="index.html">Ver landing</a>
-              </div>
-              <div id="slotAssignments" class="slot-grid" aria-live="polite"></div>
-            </section>
-
             <section class="admin-card shadow-soft content-card">
               <div class="section-heading">
                 <div>
-                  <h2>Personaliza textos y títulos</h2>
+                  <h2>Configura cada sección del landing</h2>
                   <p class="admin-note">
-                    Ajusta los encabezados y mensajes principales para que reflejen la voz de tu marca.
-                    Los cambios se aplican inmediatamente en el landing.
+                    Selecciona las imágenes y ajusta los textos sin salir del mismo bloque. Los cambios se
+                    guardan automáticamente en tu navegador.
                   </p>
                 </div>
-                <button class="btn btn-secondary" type="button" id="resetContentButton">
-                  Restablecer todos los textos
-                </button>
+                <div class="section-actions">
+                  <a class="btn btn-secondary" href="index.html">Ver landing</a>
+                  <button class="btn btn-secondary" type="button" id="resetContentButton">
+                    Restablecer todos los textos
+                  </button>
+                </div>
               </div>
               <p class="form-message" id="contentMessage" aria-live="polite"></p>
-              <div id="contentEditor" class="content-grid"></div>
+              <div id="landingSections" class="landing-sections" aria-live="polite"></div>
             </section>
           </div>
         </div>

--- a/main.css
+++ b/main.css
@@ -393,9 +393,31 @@ textarea {
   gap: 16px;
 }
 .flow-list li {
+  list-style: none;
+}
+.flow-link {
   display: flex;
   align-items: flex-start;
   gap: 14px;
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: transparent;
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: border 0.2s ease, background 0.2s ease, transform 0.15s ease;
+}
+.flow-link:hover,
+.flow-link:focus-visible {
+  border-color: rgba(37, 116, 175, 0.28);
+  background: rgba(37, 116, 175, 0.08);
+  outline: none;
+}
+.flow-link:active {
+  transform: translateY(1px);
 }
 .flow-step {
   width: 32px;
@@ -437,7 +459,11 @@ textarea {
   display: grid;
   gap: 24px;
   margin-top: 0;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  align-items: stretch;
+}
+.admin-layout > .admin-card {
+  height: 100%;
 }
 .admin-card {
   background: #fff;
@@ -445,6 +471,12 @@ textarea {
   padding: 24px;
   display: grid;
   gap: 18px;
+}
+.section-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
 }
 .form-group {
   display: grid;
@@ -468,6 +500,10 @@ textarea {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  max-height: min(520px, 62vh);
+  overflow-y: auto;
+  padding-right: 6px;
+  scrollbar-gutter: stable both-edges;
 }
 .library-card {
   border: 1px solid #e2e8f0;
@@ -601,6 +637,63 @@ textarea {
 .reset-btn:hover,
 .reset-btn:focus {
   text-decoration: underline;
+}
+.landing-sections {
+  display: grid;
+  gap: 24px;
+}
+.landing-section {
+  border: 1px solid #e2e8f0;
+  border-radius: 18px;
+  padding: 22px;
+  background: #f8fafc;
+  display: grid;
+  gap: 18px;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  scroll-margin-top: 96px;
+}
+.landing-section:focus {
+  outline: none;
+}
+.landing-section.is-highlighted {
+  border-color: rgba(37, 116, 175, 0.6);
+  box-shadow: 0 0 0 3px rgba(37, 116, 175, 0.18);
+  background: #fff;
+}
+.landing-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.landing-section-header h3 {
+  margin: 0;
+}
+.landing-section-header .admin-note {
+  margin: 6px 0 0;
+}
+.landing-section-columns {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+.landing-section-column {
+  display: grid;
+  gap: 16px;
+}
+.landing-section-column h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+.landing-section-column .admin-note {
+  margin: 0;
+}
+.landing-section.empty {
+  border-style: dashed;
+  color: #475569;
+  text-align: center;
 }
 
 /* Footer con imagen */


### PR DESCRIPTION
## Summary
- make the landing map buttons scroll to their corresponding configuration sections
- reorganize the admin configurator into unified per-section blocks with shared styling updates
- improve spacing for the library and layout so large image sets remain manageable

## Testing
- Not run (static files)

------
https://chatgpt.com/codex/tasks/task_e_68d0f0192bc08325be26eb69951e35ee