### PR TITLE
Enable inline editing of promo text from admin cards

### DIFF
--- a/main.css
+++ b/main.css
@@ -837,36 +837,70 @@ textarea {
   display: grid;
   gap: 12px;
 }
-.slot-card img {
+.slot-card__media {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  isolation: isolate;
+}
+.slot-card__media img {
   width: 100%;
   border-radius: 14px;
   aspect-ratio: 16/9;
   object-fit: cover;
 }
-.slot-card h3 {
+.slot-card__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 18px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 15%, rgba(15, 23, 42, 0.85) 100%);
+}
+.slot-overlay-item {
+  color: #fff;
   margin: 0;
+  text-shadow: 0 2px 6px rgba(15, 23, 42, 0.45);
+}
+.slot-overlay-title {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+.slot-overlay-chip {
+  display: inline-flex;
+  align-self: flex-start;
+  background: rgba(15, 23, 42, 0.75);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  padding: 6px 12px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.slot-overlay-note {
+  font-size: 0.85rem;
+  opacity: 0.92;
 }
 .slot-editable {
   display: block;
   margin: 0;
   padding: 6px 10px;
-  border-radius: 10px;
+  border-radius: 12px;
   cursor: text;
   background: transparent;
   transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }
 .slot-editable:hover {
-  background: rgba(226, 232, 240, 0.6);
+  background: rgba(15, 23, 42, 0.22);
 }
 .slot-editable:focus-visible {
-  outline: 2px solid rgba(37, 116, 175, 0.5);
+  outline: 2px solid rgba(255, 255, 255, 0.8);
   outline-offset: 2px;
-  background: rgba(226, 232, 240, 0.85);
-}
-.slot-description {
-  font-size: 0.85rem;
-  color: #64748b;
-  margin: 0;
+  background: rgba(15, 23, 42, 0.36);
 }
 .slot-inline-editor {
   width: 100%;
@@ -890,6 +924,11 @@ textarea {
 .slot-status {
   font-size: 0.85rem;
   color: #475569;
+}
+.slot-tip {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin: -4px 0 0;
 }
 .slot-card select {
   padding: 10px 12px;


### PR DESCRIPTION
## Summary
- remove the unused slot text override storage in the admin panel
- render promo and destino previews with inline editors tied to the real content fields so double click edits update the landing copy
- refresh the slot card styles to show overlay text and guidance for inline editing

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d33c1589748325833a09c02e2338fe