### PR TITLE
Add scrollable body to library modal

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -236,7 +236,9 @@
             Cerrar
           </button>
         </div>
-        <div id="libraryModalList" class="library-grid library-modal__grid" aria-live="polite"></div>
+        <div class="library-modal__body">
+          <div id="libraryModalList" class="library-grid" aria-live="polite"></div>
+        </div>
       </div>
     </div>
 

--- a/main.css
+++ b/main.css
@@ -815,11 +815,12 @@ textarea {
   outline: 2px solid var(--blue);
   outline-offset: 3px;
 }
-.library-modal__grid {
+.library-modal__body {
   overflow-y: auto;
   padding-right: 8px;
   scrollbar-gutter: stable both-edges;
   max-height: 100%;
+  min-height: 0;
 }
 .no-scroll {
   overflow: hidden;


### PR DESCRIPTION
## Summary
- wrap the library grid within the modal in a dedicated scroll container
- add styles so the modal body scrolls vertically without shrinking cards

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3480e0e6c8325abae19138b07f1c6