### PR TITLE
Use SweetAlert2 for contact form alert

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,7 +501,20 @@
             Cuéntanos a dónde quieres ir y te enviamos la mejor propuesta.
           </p>
           <form
-            onsubmit="event.preventDefault(); alert('¡Gracias! Te contactaremos pronto.');"
+            onsubmit="
+              event.preventDefault();
+              if (window.Swal) {
+                Swal.fire({
+                  title: '¡Gracias!',
+                  text: 'Te contactaremos pronto.',
+                  icon: 'success',
+                  confirmButtonColor: '#0f4c81',
+                  confirmButtonText: 'Cerrar'
+                });
+              } else {
+                alert('¡Gracias! Te contactaremos pronto.');
+              }
+            "
           >
             <div
               style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px"
@@ -578,6 +591,7 @@
       </div>
     </footer>
 
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the inline browser alert in the contact form with a SweetAlert2 success modal
- load SweetAlert2 from the CDN and keep a native alert fallback when the library is unavailable

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d34af49f38832585a71674bca676e1