### PR TITLE
Use SweetAlert2 for image deletion confirmation

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -242,7 +242,7 @@
         </div>
       </div>
     </div>
-
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="admin.js"></script>
   </body>
 </html>

--- a/admin.js
+++ b/admin.js
@@ -1627,9 +1627,26 @@ function buildLibraryCard(image) {
   deleteButton.innerHTML =
     '<span class="library-delete-icon" aria-hidden="true">🗑</span><span>Eliminar</span>';
   deleteButton.addEventListener("click", () => {
-    const confirmDelete = window.confirm(
-      `¿Eliminar "${image.name}" de la biblioteca? Esta acción también quitará su uso del sitio.`
-    );
+    const message = `¿Eliminar "${image.name}" de la biblioteca? Esta acción también quitará su uso del sitio.`;
+
+    if (window.Swal) {
+      Swal.fire({
+        title: "Eliminar imagen",
+        text: message,
+        icon: "warning",
+        showCancelButton: true,
+        confirmButtonText: "Eliminar",
+        cancelButtonText: "Cancelar",
+        confirmButtonColor: "#0f4c81",
+      }).then((result) => {
+        if (result.isConfirmed) {
+          deleteImage(image.id);
+        }
+      });
+      return;
+    }
+
+    const confirmDelete = window.confirm(message);
     if (!confirmDelete) {
       return;
     }


### PR DESCRIPTION
## Summary
- load SweetAlert2 on the admin panel so it can be used for modals
- replace the image deletion confirmation with a SweetAlert2 dialog and keep a `window.confirm` fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d35ca2a3188325b4b2b7df7b3709bc