### PR TITLE
Fix login header styling

### DIFF
--- a/main.css
+++ b/main.css
@@ -456,6 +456,13 @@ textarea {
 .auth-header {
   display: grid;
   gap: 10px;
+  position: static;
+  inset: auto;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  backdrop-filter: none;
+  box-shadow: none;
 }
 
 .auth-accent {


### PR DESCRIPTION
## Summary
- ensure the login card header keeps its place inside the card layout by removing the global fixed-header styles from it
- keep the login introductory block visible with transparent background and no global header effects

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d383e8a68883258d381b40f6198266